### PR TITLE
AppleAppAttest: don't populate attestation trust anchor to receipt validator

### DIFF
--- a/src/main/kotlin/ch/veehait/devicecheck/appattest/AppleAppAttest.kt
+++ b/src/main/kotlin/ch/veehait/devicecheck/appattest/AppleAppAttest.kt
@@ -53,7 +53,7 @@ class AppleAppAttest(
     fun createAttestationValidator(
         trustAnchor: TrustAnchor = AttestationValidator.APPLE_APP_ATTEST_ROOT_CA_BUILTIN_TRUST_ANCHOR,
         clock: Clock = Clock.systemUTC(),
-        receiptValidator: ReceiptValidator = createReceiptValidator(trustAnchor, clock),
+        receiptValidator: ReceiptValidator = createReceiptValidator(clock = clock),
     ): AttestationValidator = AttestationValidatorImpl(
         app = app,
         appleAppAttestEnvironment = appleAppAttestEnvironment,

--- a/src/test/kotlin/ch/veehait/devicecheck/appattest/attestation/AttestationValidatorTest.kt
+++ b/src/test/kotlin/ch/veehait/devicecheck/appattest/attestation/AttestationValidatorTest.kt
@@ -44,9 +44,6 @@ class AttestationValidatorTest : FreeSpec() {
         val appleAppAttest = this.defaultAppleAppAttest()
         return appleAppAttest.createAttestationValidator(
             clock = timestamp.fixedUtcClock(),
-            receiptValidator = appleAppAttest.createReceiptValidator(
-                clock = timestamp.fixedUtcClock(),
-            )
         )
     }
 


### PR DESCRIPTION
The default value to the argument `receiptValidator` of `AppleAppAttest.createAttestationValidator` created an instance of `ReceiptValidator` using the same trust anchor as for the `AttestationValdiator`. As attestations and receipts have different root certificates, this behavior caused the attestation object's enclosed receipt to fail the validation.

Added a commit to no longer populate the attestation validator's trust anchor to the receipt validator's trust anchor when calling `AppleAppAttest.createAttestationValidator`. Instead, it uses `AppleAppAttest.createReceiptValidator`'s default value for the `trustAnchor` argument.

Closes #9 