### PR TITLE
ReceiptValidator: rename `notAfter` to `notBefore`

### DIFF
--- a/src/test/kotlin/ch/veehait/devicecheck/appattest/attestation/AttestationValidatorTest.kt
+++ b/src/test/kotlin/ch/veehait/devicecheck/appattest/attestation/AttestationValidatorTest.kt
@@ -260,7 +260,7 @@ class AttestationValidatorTest : FreeSpec() {
                             override suspend fun validateReceiptAsync(
                                 receiptP7: ByteArray,
                                 publicKey: ECPublicKey,
-                                notAfter: Instant,
+                                notBefore: Instant,
                             ): Receipt {
                                 throw ReceiptException.InvalidPayload("Always rejected")
                             }
@@ -268,7 +268,7 @@ class AttestationValidatorTest : FreeSpec() {
                             override fun validateReceipt(
                                 receiptP7: ByteArray,
                                 publicKey: ECPublicKey,
-                                notAfter: Instant,
+                                notBefore: Instant,
                             ): Receipt {
                                 throw ReceiptException.InvalidPayload("Always rejected")
                             }

--- a/src/test/kotlin/ch/veehait/devicecheck/appattest/receipt/ReceiptValidatorTest.kt
+++ b/src/test/kotlin/ch/veehait/devicecheck/appattest/receipt/ReceiptValidatorTest.kt
@@ -122,7 +122,10 @@ class ReceiptValidatorTest : FreeSpec() {
                                     )
                                 }
                                 val expectedTime = sample.properties.creationTime.plusNanos(nanosOffset)
-                                exception.shouldHaveMessage("Receipt's creation time is after $expectedTime")
+                                exception.shouldHaveMessage(
+                                    "Receipt's creation time is too far in the past. " +
+                                        "Expected a timestamp no older than $expectedTime",
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
So far, the functions `validateReceiptAsync` and `validateReceipt` had been accepting an argument `notAfter` which denoted a timestamp. If a receipt contains a timestamp which is before this deadline, it is considered expired. Therefore, the argument should have the name `notBefore`. This is also in line with X.509 certificates which use the same name to mark the beginning of the validity period.

Please note that the actual logic is unchanged and has been working correctly.

Fixes #37.